### PR TITLE
Add the capability to call the API to get the list of labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ jobs:
           labels: "semver:patch, semver:minor, semver:major"
 ```
 
+By default this actions reads `event.json`, which will not detect when a label is added in an earlier step.
+To force an API call, set the `GITHUB_TOKEN` environment variable like so:
+
+```yaml
+- uses: mheap/github-action-required-labels@v1
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  with:
+    mode: exactly
+    count: 1
+    labels: "semver:patch, semver:minor, semver:major"
+```
+
 ### Prevent merging if a label exists
 
 ```yaml

--- a/index.js
+++ b/index.js
@@ -27,9 +27,16 @@ Toolkit.run(async (tools) => {
     return;
   }
 
-  const appliedLabels = tools.context.payload.pull_request.labels.map(
-    (label) => label.name
-  );
+  // If a token is provided, call the API, otherwise read the event.json file
+  let labels;
+  if (process.env.GITHUB_TOKEN) {
+    labels = (await tools.github.issues.listLabelsOnIssue(tools.context.issue))
+      .data;
+  } else {
+    labels = tools.context.payload.pull_request.labels;
+  }
+
+  const appliedLabels = labels.map((label) => label.name);
 
   let intersection = allowedLabels.filter((x) => appliedLabels.includes(x));
 


### PR DESCRIPTION
This is required when a prior step may add a label as the event.json is not
updated with new labels

Resolves #14 