### PR TITLE
Add support for output status

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ Toolkit.run(async (tools) => {
   let intersection = allowedLabels.filter((x) => appliedLabels.includes(x));
 
   if (mode === "exactly" && intersection.length !== count) {
+    tools.outputs.status = "failure";
     tools.exit[exitType](
       `Label error. Requires exactly ${count} of: ${allowedLabels.join(
         ", "
@@ -64,6 +65,7 @@ Toolkit.run(async (tools) => {
   }
 
   if (mode === "minimum" && intersection.length < count) {
+    tools.outputs.status = "failure";
     tools.exit[exitType](
       `Label error. Requires at least ${count} of: ${allowedLabels.join(
         ", "
@@ -73,6 +75,7 @@ Toolkit.run(async (tools) => {
   }
 
   if (mode === "maximum" && intersection.length > count) {
+    tools.outputs.status = "failure";
     tools.exit[exitType](
       `Label error. Requires at most ${count} of: ${allowedLabels.join(
         ", "
@@ -81,5 +84,6 @@ Toolkit.run(async (tools) => {
     return;
   }
 
+  tools.outputs.status = "success";
   tools.exit.success("Complete");
 });

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,5 @@
 const { Toolkit } = require("actions-toolkit");
+const core = require("@actions/core");
 const mockedEnv = require("mocked-env");
 
 describe("Required Labels", () => {
@@ -36,6 +37,7 @@ describe("Required Labels", () => {
     tools.exit.success = jest.fn();
     tools.exit.failure = jest.fn();
     tools.exit.neutral = jest.fn();
+    core.setOutput = jest.fn();
   });
 
   afterEach(() => {
@@ -54,6 +56,8 @@ describe("Required Labels", () => {
       });
 
       action(tools);
+      expect(core.setOutput).toBeCalledTimes(1);
+      expect(core.setOutput).toBeCalledWith("status", "success");
       expect(tools.exit.success).toBeCalledTimes(1);
       expect(tools.exit.success).toBeCalledWith("Complete");
     });
@@ -67,6 +71,8 @@ describe("Required Labels", () => {
       });
 
       action(tools);
+      expect(core.setOutput).toBeCalledTimes(1);
+      expect(core.setOutput).toBeCalledWith("status", "success");
       expect(tools.exit.success).toBeCalledTimes(1);
       expect(tools.exit.success).toBeCalledWith("Complete");
     });
@@ -80,6 +86,8 @@ describe("Required Labels", () => {
       });
 
       action(tools);
+      expect(core.setOutput).toBeCalledTimes(1);
+      expect(core.setOutput).toBeCalledWith("status", "success");
       expect(tools.exit.success).toBeCalledTimes(1);
       expect(tools.exit.success).toBeCalledWith("Complete");
     });
@@ -95,6 +103,8 @@ describe("Required Labels", () => {
       });
 
       action(tools);
+      expect(core.setOutput).toBeCalledTimes(1);
+      expect(core.setOutput).toBeCalledWith("status", "failure");
       expect(tools.exit.failure).toBeCalledTimes(1);
       expect(tools.exit.failure).toBeCalledWith(
         "Label error. Requires exactly 1 of: enhancement, bug. Found: enhancement, bug"
@@ -110,6 +120,8 @@ describe("Required Labels", () => {
       });
 
       action(tools);
+      expect(core.setOutput).toBeCalledTimes(1);
+      expect(core.setOutput).toBeCalledWith("status", "failure");
       expect(tools.exit.failure).toBeCalledTimes(1);
       expect(tools.exit.failure).toBeCalledWith(
         "Label error. Requires at least 2 of: enhancement, bug, triage. Found: enhancement"
@@ -125,6 +137,8 @@ describe("Required Labels", () => {
       });
 
       action(tools);
+      expect(core.setOutput).toBeCalledTimes(1);
+      expect(core.setOutput).toBeCalledWith("status", "failure");
       expect(tools.exit.failure).toBeCalledTimes(1);
       expect(tools.exit.failure).toBeCalledWith(
         "Label error. Requires at most 2 of: enhancement, bug, triage. Found: enhancement, triage, bug"


### PR DESCRIPTION
#23 requested the ability to change the exit code to `neutral` to mark the check as skipped. Unfortunately GH Actions hasn't supported this for a while (see #31), and it's hard to check the exit code in Actions.

This PR adds a new output which can be used to check the actual status of the action when `exit_type` is set to `success`.

You can set `exit_type` to success then inspect `outputs.status` to see if the action passed or failed. This is useful when you want to perform additional actions if a label is not present, but not fail the entire build.

If the action passed, `outputs.status` will be `success`. If it failed, `outputs.status` will be `failure`.

Here is a complete workflow example for this use case:

```yaml
name: Pull Request Labels
on:
  pull_request:
    types: [opened, labeled, unlabeled, synchronize]
jobs:
  label:
    runs-on: ubuntu-latest
    outputs:
      status: ${{ steps.check-labels.outputs.status }}
    steps:
      - id: check-labels
        uses: mheap/github-action-required-labels@v2
        with:
          mode: exactly
          count: 1
          labels: "semver:patch, semver:minor, semver:major"
          exit_type: success
  do-other:
    runs-on: ubuntu-latest
    needs: label
    steps:
      - run: echo SUCCESS
        if: needs.label.outputs.status == 'success'
      - run: echo FAILURE && exit 1
        if: needs.label.outputs.status == 'failure'
```