### PR TITLE
Add issues/pull-requests permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
     steps:
       - uses: mheap/github-action-required-labels@v3
         with:
@@ -122,6 +125,9 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
     outputs:
       status: ${{ steps.check-labels.outputs.status }}
     steps:


### PR DESCRIPTION
The `github.token` previously had permission to access everything. The defaults for this changed a little while ago and the token could no longer access PR endpoints (see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs for more information).

This PR adds example permissions to the README so that the action can be used on private repos (public repos have always worked)

Resolves #49 