### PR TITLE
Add newline after the match token in error comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const core = require("@actions/core");
 const github = require("@actions/github");
 
-const matchToken = `<!-- reqlabelmessage -->`;
+const matchToken = `<!-- reqlabelmessage -->\n`;
 async function action() {
   try {
     const token = core.getInput("token", { required: true });
@@ -128,7 +128,7 @@ async function exitWithError(exitType, octokit, shouldAddComment, message) {
     const params = {
       ...github.context.repo,
       issue_number: github.context.issue.number,
-      body: `${matchToken}\n${message}`,
+      body: `${matchToken}${message}`,
     };
 
     // If so, update it

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ async function exitWithError(exitType, octokit, shouldAddComment, message) {
     const params = {
       ...github.context.repo,
       issue_number: github.context.issue.number,
-      body: `${matchToken}${message}`,
+      body: `${matchToken}\n${message}`,
     };
 
     // If so, update it

--- a/index.test.js
+++ b/index.test.js
@@ -6,7 +6,7 @@ const mockedEnv = require("mocked-env");
 const nock = require("nock");
 nock.disableNetConnect();
 
-const matchToken = `<!-- reqlabelmessage -->`;
+const matchToken = `<!-- reqlabelmessage -->\n`;
 
 describe("Required Labels", () => {
   let restore;


### PR DESCRIPTION
For some reason, Github's rendering of markdown is disabled on any line that starts with a comment (`<!-- -->`). However, markdown rendering resumes on the next line.

This is an easy fix which just adds a newline after the match token.

## Testing

I've tested this in my own environment and it works as expected.