### PR TITLE
fix: merge-queue support

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ async function action() {
 
     let providedLabels = core.getInput("labels", { required: true });
 
+    core.debug(`gather labels: ${providedLabels}`);
     if (labelsAreRegex) {
       // If labels are regex they must be provided as new line delimited
       providedLabels = providedLabels.split("\n");
@@ -81,7 +82,7 @@ async function action() {
       return;
     }
 
-    // Fetch the labels using the API
+    core.debug(`fetch the labels using the API`);
     // We use the API rather than read event.json in case earlier steps
     // added a label
     const labels = (
@@ -110,7 +111,7 @@ async function action() {
       );
     }
 
-    // Is there an error?
+    core.debug(`detect errors...`);
     let errorMode;
     if (mode === "exactly" && intersection.length !== count) {
       errorMode = "exactly";
@@ -120,7 +121,7 @@ async function action() {
       errorMode = "at most";
     }
 
-    // If so, add a comment (if enabled) and fail the run
+    core.debug(`if so, add a comment (if enabled) and fail the run...`);
     if (errorMode !== undefined) {
       const comment = core.getInput("message");
       const errorMessage = tmpl(comment, {
@@ -135,7 +136,7 @@ async function action() {
       return;
     }
 
-    // Remove the comment if it exists
+    core.debug(`remove the comment if it exists...`);
     if (shouldAddComment) {
       const { data: existing } = await octokit.rest.issues.listComments({
         ...github.context.repo,

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ async function action() {
 
     let issue_number = github.context.issue.number;
 
-    if (github.context.eventName == "merge_queue") {
+    if (github.context.eventName === "merge_queue") {
       // Parse out of the ref for merge queue
       // e.g. refs/heads/gh-readonly-queue/main/pr-17-a3c310584587d4b97c2df0cb46fe050cc46a15d6
       const lastPart = github.context.ref.split("/").pop();

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ async function action() {
 
     let issue_number = github.context.issue.number;
 
-    if (!issue_number && github.context.eventName == "merge_queue") {
+    if (github.context.eventName == "merge_queue") {
       // Parse out of the ref for merge queue
       // e.g. refs/heads/gh-readonly-queue/main/pr-17-a3c310584587d4b97c2df0cb46fe050cc46a15d6
       const lastPart = github.context.ref.split("/").pop();
@@ -82,7 +82,7 @@ async function action() {
       return;
     }
 
-    core.debug(`fetch the labels using the API`);
+    core.debug(`fetch the labels for ${issue_number} using the API`);
     // We use the API rather than read event.json in case earlier steps
     // added a label
     const labels = (

--- a/index.js
+++ b/index.js
@@ -46,12 +46,12 @@ async function action() {
 
     let issue_number = github.context.issue.number;
 
-    if (github.context.eventName === "merge_queue") {
+    if (github.context.eventName === "merge_group") {
       // Parse out of the ref for merge queue
       // e.g. refs/heads/gh-readonly-queue/main/pr-17-a3c310584587d4b97c2df0cb46fe050cc46a15d6
       const lastPart = github.context.ref.split("/").pop();
       issue_number = lastPart.match(/pr-(\d+)-/)[1];
-      core.info(`merge_queue event detected and issue_number parsed as ${issue_number}`);
+      core.info(`merge_group event detected and issue_number parsed as ${issue_number}`);
     }
 
     const allowedModes = ["exactly", "minimum", "maximum"];

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ async function action() {
       // e.g. refs/heads/gh-readonly-queue/main/pr-17-a3c310584587d4b97c2df0cb46fe050cc46a15d6
       const lastPart = github.context.ref.split("/").pop();
       issue_number = lastPart.match(/pr-(\d+)-/)[1];
+      core.info(`merge_queue event detected and issue_number parsed as ${issue_number}`);
     }
 
     const allowedModes = ["exactly", "minimum", "maximum"];


### PR DESCRIPTION
This should help with supporting the `merge-queue`:

1) The name of the event is `merge_group`
2) `github.context.issue.number` was referenced in a few places, so I changed some signatures and use `issue_number`
3) Add some debug records so it can help with running the action in debug mode.


### Test

See https://github.com/elastic/oblt-actions/pull/160#event-15261048545

Resolves #66 